### PR TITLE
Fix OAuth redirect setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CALLBACK_URL=http://localhost:8080/forum/api/auth/google/callback

--- a/API/handlers/oauth_google.go
+++ b/API/handlers/oauth_google.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -24,10 +25,16 @@ type GoogleOAuthHandler struct {
 
 // NewGoogleOAuthHandler creates a GoogleOAuthHandler with config from environment variables.
 func NewGoogleOAuthHandler(userRepo *repository.UserRepository, sessionRepo *repository.SessionRepository) *GoogleOAuthHandler {
+	clientID := os.Getenv("GOOGLE_CLIENT_ID")
+	clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
+	redirectURL := os.Getenv("GOOGLE_CALLBACK_URL")
+	if redirectURL == "" {
+		log.Fatal("GOOGLE_CALLBACK_URL environment variable is not set")
+	}
 	cfg := &oauth2.Config{
-		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
-		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
-		RedirectURL:  os.Getenv("GOOGLE_CALLBACK_URL"),
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
 		Scopes: []string{
 			"https://www.googleapis.com/auth/userinfo.email",
 			"https://www.googleapis.com/auth/userinfo.profile",

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Forum Application
+
+This repository contains a simple forum backend (API) and frontend (UI). The API uses Google OAuth for authentication.
+
+## Quick Start
+
+1. Copy `.env.example` to `.env` and provide your Google OAuth credentials:
+   ```bash
+   cp .env.example .env
+   # edit .env and fill GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
+   ```
+2. Ensure `GOOGLE_CALLBACK_URL` in `.env` matches the authorized redirect URI in your Google console.
+3. Build and start the application using Docker Compose:
+   ```bash
+   docker compose up --build
+   ```
+4. Open `http://localhost:8081` in your browser. Register with Google should now redirect correctly.
+
+## Manual API Testing
+
+See `instructions.md` for curl commands to interact with the API.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./API
       dockerfile: Dockerfile
+    env_file:
+      - .env
     ports:
       - "8080:8080"  # optional; for debugging
     networks:
@@ -19,7 +21,7 @@ services:
     depends_on:
       - api
     environment:
-      - API_URL=http://api:8081
+      - API_URL=http://api:8080
     networks:
       - backend
 


### PR DESCRIPTION
## Summary
- configure API service via `.env`
- document setup steps in README
- validate `GOOGLE_CALLBACK_URL` in OAuth handler

## Testing
- `go test ./...` *(fails: downloading toolchain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68639905f2bc8324a94617be50f0eda5