### PR TITLE
Add extensible OAuth provider interface

### DIFF
--- a/API/config/schema_config.go
+++ b/API/config/schema_config.go
@@ -10,7 +10,6 @@ const CreatePostCategoriesTable = `CREATE TABLE IF NOT EXISTS post_categories (
     FOREIGN KEY (category_id) REFERENCES categories(category_id) ON DELETE CASCADE
 );`
 
-
 const CreateUserTable = `CREATE TABLE IF NOT EXISTS user (
             user_id TEXT PRIMARY KEY,
             username TEXT NOT NULL UNIQUE CHECK (LENGTH(username) <= 50),
@@ -20,7 +19,16 @@ const CreateUserTable = `CREATE TABLE IF NOT EXISTS user (
 
 const CreateUserAuthTable = `CREATE TABLE IF NOT EXISTS user_auth (
             user_id TEXT PRIMARY KEY,
-            password_hash TEXT NOT NULL CHECK (LENGTH(password_hash) <= 255),
+            password_hash TEXT CHECK (LENGTH(password_hash) <= 255),
+            FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
+        );`
+
+const CreateUserProvidersTable = `CREATE TABLE IF NOT EXISTS user_providers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            provider_id TEXT NOT NULL,
+            UNIQUE(provider, provider_id),
             FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
         );`
 
@@ -34,12 +42,11 @@ const CreateSessionsTable = `CREATE TABLE IF NOT EXISTS sessions (
     FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
 );`
 
-
 const CreateCategoriesTable = `CREATE TABLE IF NOT EXISTS categories (
             category_id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL UNIQUE CHECK (LENGTH(name) <= 100)
         );`
-		
+
 const CreatePostsTable = `CREATE TABLE IF NOT EXISTS posts (
     post_id TEXT PRIMARY KEY,
     user_id TEXT NOT NULL,
@@ -49,7 +56,6 @@ const CreatePostsTable = `CREATE TABLE IF NOT EXISTS posts (
     updated_at TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
 );`
-
 
 const CreateCommentsTable = `CREATE TABLE IF NOT EXISTS comments (
             comment_id TEXT PRIMARY KEY,

--- a/API/handlers/oauth_handlers.go
+++ b/API/handlers/oauth_handlers.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"net/http"
+
+	"forum/models"
+	"forum/oauth"
+	"forum/repository"
+	"forum/utils"
+)
+
+// OAuthHandler manages OAuth login flows
+type OAuthHandler struct {
+	UserRepo    *repository.UserRepository
+	SessionRepo *repository.SessionRepository
+}
+
+func NewOAuthHandler(userRepo *repository.UserRepository, sessionRepo *repository.SessionRepository) *OAuthHandler {
+	return &OAuthHandler{UserRepo: userRepo, SessionRepo: sessionRepo}
+}
+
+func (h *OAuthHandler) login(w http.ResponseWriter, r *http.Request, p oauth.Provider) {
+	state := utils.GenerateCSRFToken()
+	http.SetCookie(w, &http.Cookie{Name: "oauth_state", Value: state, Path: "/", HttpOnly: true, MaxAge: 300})
+	http.Redirect(w, r, p.AuthCodeURL(state), http.StatusFound)
+}
+
+func (h *OAuthHandler) GoogleLoginHandler(w http.ResponseWriter, r *http.Request) {
+	h.login(w, r, oauth.GoogleProvider{})
+}
+
+func (h *OAuthHandler) GoogleCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	h.handleCallback(w, r, oauth.GoogleProvider{})
+}
+
+func (h *OAuthHandler) GitHubLoginHandler(w http.ResponseWriter, r *http.Request) {
+	h.login(w, r, oauth.GitHubProvider{})
+}
+
+func (h *OAuthHandler) GitHubCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	h.handleCallback(w, r, oauth.GitHubProvider{})
+}
+
+func (h *OAuthHandler) handleCallback(w http.ResponseWriter, r *http.Request, p oauth.Provider) {
+	stateCookie, err := r.Cookie("oauth_state")
+	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "code not found", http.StatusBadRequest)
+		return
+	}
+	token, err := p.Exchange(code)
+	if err != nil {
+		http.Error(w, "token exchange failed", http.StatusInternalServerError)
+		return
+	}
+	email, pid, name, err := p.User(token)
+	if err != nil {
+		http.Error(w, "failed to fetch user", http.StatusInternalServerError)
+		return
+	}
+	user, err := h.UserRepo.FindOrCreateOAuthUser(email, name, p.Name(), pid)
+	if err != nil {
+		http.Error(w, "failed to create user", http.StatusInternalServerError)
+		return
+	}
+	csrfToken := utils.GenerateCSRFToken()
+	session, err := h.SessionRepo.Create(user.ID, r.RemoteAddr, csrfToken)
+	if err != nil {
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{Name: "session_id", Value: session.SessionID, Path: "/", HttpOnly: true, Secure: false, SameSite: http.SameSiteLaxMode})
+	utils.JSONResponse(w, models.LoginResponse{User: *user, SessionID: session.SessionID, CSRFToken: csrfToken}, http.StatusOK)
+}

--- a/API/models/database_model.go
+++ b/API/models/database_model.go
@@ -79,6 +79,7 @@ func createTables(db *sql.DB) error {
 	tableStatements := []string{
 		config.CreateUserTable,
 		config.CreateUserAuthTable,
+		config.CreateUserProvidersTable,
 		config.CreateSessionsTable,
 		config.CreateCategoriesTable,
 		config.CreatePostsTable,

--- a/API/models/user_model.go
+++ b/API/models/user_model.go
@@ -18,6 +18,14 @@ type UserAuth struct {
 	PasswordHash string `json:"-"`
 }
 
+// UserProvider links a user with an OAuth provider
+type UserProvider struct {
+	ID         int    `json:"id"`
+	UserID     string `json:"user_id"`
+	Provider   string `json:"provider"`
+	ProviderID string `json:"provider_id"`
+}
+
 // UserRegistration is used for registration requests
 type UserRegistration struct {
 	Username string `json:"username" binding:"required"`
@@ -33,12 +41,12 @@ type UserLogin struct {
 
 // Session represents a user session
 type Session struct {
-	UserID     string    `json:"user_id"`
-	SessionID  string    `json:"session_id"`
-	CSRFToken  string    `json:"csrf_token"` // CSRF token for security
-	IPAddress  string    `json:"ip_address"`
-	CreatedAt  time.Time `json:"created_at"`
-	ExpiresAt  time.Time `json:"expires_at"`
+	UserID    string    `json:"user_id"`
+	SessionID string    `json:"session_id"`
+	CSRFToken string    `json:"csrf_token"` // CSRF token for security
+	IPAddress string    `json:"ip_address"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 // LoginResponse is the response after successful login
@@ -47,10 +55,3 @@ type LoginResponse struct {
 	SessionID string `json:"session_id"`
 	CSRFToken string `json:"csrf_token"`
 }
-
-
-
-
-
-
-

--- a/API/oauth/providers.go
+++ b/API/oauth/providers.go
@@ -1,0 +1,183 @@
+package oauth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// Provider defines methods required to implement an OAuth provider.
+type Provider interface {
+	// Name returns the provider identifier (e.g. "google").
+	Name() string
+	// AuthCodeURL returns the authorization URL for the given state.
+	AuthCodeURL(state string) string
+	// Exchange exchanges an authorization code for an access token.
+	Exchange(code string) (string, error)
+	// User retrieves the user's email, provider user ID and display name.
+	User(token string) (email, id, name string, err error)
+}
+
+// ---------------- Google provider ----------------
+
+type GoogleProvider struct{}
+
+type googleToken struct {
+	AccessToken string `json:"access_token"`
+}
+
+type googleUser struct {
+	ID            string `json:"sub"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Name          string `json:"name"`
+}
+
+func (GoogleProvider) Name() string { return "google" }
+
+func (GoogleProvider) AuthCodeURL(state string) string {
+	q := url.Values{}
+	q.Set("client_id", os.Getenv("GOOGLE_CLIENT_ID"))
+	q.Set("redirect_uri", os.Getenv("GOOGLE_REDIRECT_URL"))
+	q.Set("response_type", "code")
+	q.Set("scope", "openid email profile")
+	q.Set("state", state)
+	return "https://accounts.google.com/o/oauth2/v2/auth?" + q.Encode()
+}
+
+func (GoogleProvider) Exchange(code string) (string, error) {
+	data := url.Values{}
+	data.Set("client_id", os.Getenv("GOOGLE_CLIENT_ID"))
+	data.Set("client_secret", os.Getenv("GOOGLE_CLIENT_SECRET"))
+	data.Set("code", code)
+	data.Set("grant_type", "authorization_code")
+	data.Set("redirect_uri", os.Getenv("GOOGLE_REDIRECT_URL"))
+	resp, err := http.PostForm("https://oauth2.googleapis.com/token", data)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var t googleToken
+	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
+		return "", err
+	}
+	if t.AccessToken == "" {
+		return "", errors.New("no access token")
+	}
+	return t.AccessToken, nil
+}
+
+func (GoogleProvider) User(token string) (string, string, string, error) {
+	req, _ := http.NewRequest("GET", "https://www.googleapis.com/oauth2/v3/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", "", err
+	}
+	defer resp.Body.Close()
+	var u googleUser
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return "", "", "", err
+	}
+	if !u.EmailVerified {
+		return "", "", "", errors.New("email not verified")
+	}
+	return strings.ToLower(u.Email), u.ID, u.Name, nil
+}
+
+// ---------------- GitHub provider ----------------
+
+type GitHubProvider struct{}
+
+type githubToken struct {
+	AccessToken string `json:"access_token"`
+}
+
+type githubUser struct {
+	ID    int    `json:"id"`
+	Login string `json:"login"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+func (GitHubProvider) Name() string { return "github" }
+
+func (GitHubProvider) AuthCodeURL(state string) string {
+	q := url.Values{}
+	q.Set("client_id", os.Getenv("GITHUB_CLIENT_ID"))
+	q.Set("redirect_uri", os.Getenv("GITHUB_REDIRECT_URL"))
+	q.Set("scope", "user:email")
+	q.Set("state", state)
+	return "https://github.com/login/oauth/authorize?" + q.Encode()
+}
+
+func (GitHubProvider) Exchange(code string) (string, error) {
+	data := url.Values{}
+	data.Set("client_id", os.Getenv("GITHUB_CLIENT_ID"))
+	data.Set("client_secret", os.Getenv("GITHUB_CLIENT_SECRET"))
+	data.Set("code", code)
+	data.Set("redirect_uri", os.Getenv("GITHUB_REDIRECT_URL"))
+
+	req, _ := http.NewRequest("POST", "https://github.com/login/oauth/access_token", strings.NewReader(data.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var t githubToken
+	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
+		return "", err
+	}
+	if t.AccessToken == "" {
+		return "", errors.New("no access token")
+	}
+	return t.AccessToken, nil
+}
+
+func (GitHubProvider) User(token string) (string, string, string, error) {
+	req, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", "", err
+	}
+	defer resp.Body.Close()
+	var u githubUser
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return "", "", "", err
+	}
+	email := strings.ToLower(u.Email)
+	if email == "" {
+		req2, _ := http.NewRequest("GET", "https://api.github.com/user/emails", nil)
+		req2.Header.Set("Authorization", "Bearer "+token)
+		req2.Header.Set("Accept", "application/vnd.github+json")
+		resp2, err := http.DefaultClient.Do(req2)
+		if err == nil {
+			defer resp2.Body.Close()
+			var emails []struct {
+				Email    string `json:"email"`
+				Primary  bool   `json:"primary"`
+				Verified bool   `json:"verified"`
+			}
+			if err := json.NewDecoder(resp2.Body).Decode(&emails); err == nil {
+				for _, e := range emails {
+					if e.Primary && e.Verified {
+						email = strings.ToLower(e.Email)
+						break
+					}
+				}
+			}
+		}
+	}
+	if email == "" {
+		return "", "", "", errors.New("no verified email")
+	}
+	return email, fmt.Sprintf("%d", u.ID), u.Login, nil
+}

--- a/API/repository/user_repository.go
+++ b/API/repository/user_repository.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"forum/models"
@@ -15,6 +16,7 @@ var (
 	ErrEmailTaken         = errors.New("email is already taken")
 	ErrUsernameTaken      = errors.New("username is already taken")
 	ErrInvalidCredentials = errors.New("invalid credentials")
+	ErrPasswordNotSet     = errors.New("password not set; login with oauth")
 )
 
 // UserRepository handles user-related database operations
@@ -184,16 +186,116 @@ func (r *UserRepository) Authenticate(login models.UserLogin) (*models.User, err
 	// Get the user's authentication data
 	auth, err := r.GetAuthByUserID(user.ID)
 	if err != nil {
-		fmt.Println("Auth record not found")
+		if err == ErrUserNotFound {
+			return nil, ErrPasswordNotSet
+		}
 		return nil, err
 	}
-	fmt.Println("Stored hash:", auth.PasswordHash)
-	fmt.Println("Password match?", utils.CheckPasswordHash(login.Password, auth.PasswordHash))
 
-	// Check the password
+	if auth.PasswordHash == "" {
+		return nil, ErrPasswordNotSet
+	}
+
 	if !utils.CheckPasswordHash(login.Password, auth.PasswordHash) {
 		return nil, ErrInvalidCredentials
 	}
 
 	return user, nil
+}
+
+// FindOrCreateOAuthUser looks up a user by provider credentials or email and creates
+// a new account if none exists. Username uniqueness is ensured.
+func (r *UserRepository) FindOrCreateOAuthUser(email, name, provider, providerID string) (*models.User, error) {
+	// Try by provider
+	user, err := r.GetByProvider(provider, providerID)
+	if err == nil {
+		return user, nil
+	}
+
+	// Try by email
+	user, err = r.GetByEmail(email)
+	if err == nil {
+		// link provider
+		if err := r.LinkProvider(user.ID, provider, providerID); err != nil && err != sql.ErrNoRows {
+			return nil, err
+		}
+		return user, nil
+	}
+
+	if err != ErrUserNotFound {
+		return nil, err
+	}
+
+	// Ensure unique username derived from name or email
+	base := strings.TrimSpace(name)
+	if base == "" {
+		base = strings.Split(email, "@")[0]
+	}
+	username := base
+	i := 1
+	for {
+		var count int
+		if err := r.DB.QueryRow("SELECT COUNT(*) FROM user WHERE username = ?", username).Scan(&count); err != nil {
+			return nil, err
+		}
+		if count == 0 {
+			break
+		}
+		username = fmt.Sprintf("%s%d", base, i)
+		i++
+	}
+
+	tx, err := r.DB.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	userID := utils.GenerateUUID()
+	createdAt := time.Now()
+	if _, err := tx.Exec(`INSERT INTO user (user_id, username, email, created_at) VALUES (?, ?, ?, ?)`, userID, username, email, createdAt); err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(`INSERT INTO user_providers (user_id, provider, provider_id) VALUES (?, ?, ?)`, userID, provider, providerID); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &models.User{ID: userID, Username: username, Email: email, CreatedAt: createdAt}, nil
+}
+
+// GetByProvider returns user by provider and id
+func (r *UserRepository) GetByProvider(provider, providerID string) (*models.User, error) {
+	query := `SELECT u.user_id, u.username, u.email, u.created_at FROM user u JOIN user_providers up ON u.user_id = up.user_id WHERE up.provider = ? AND up.provider_id = ?`
+	var u models.User
+	var created time.Time
+	err := r.DB.QueryRow(query, provider, providerID).Scan(&u.ID, &u.Username, &u.Email, &created)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrUserNotFound
+		}
+		return nil, err
+	}
+	u.CreatedAt = created
+	return &u, nil
+}
+
+// LinkProvider associates an OAuth provider with an existing user
+func (r *UserRepository) LinkProvider(userID, provider, providerID string) error {
+	_, err := r.DB.Exec(`INSERT OR IGNORE INTO user_providers (user_id, provider, provider_id) VALUES (?, ?, ?)`, userID, provider, providerID)
+	return err
+}
+
+// HasPassword checks if the user has a password set
+func (r *UserRepository) HasPassword(userID string) (bool, error) {
+	var hash sql.NullString
+	err := r.DB.QueryRow(`SELECT password_hash FROM user_auth WHERE user_id = ?`, userID).Scan(&hash)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return hash.Valid && hash.String != "", nil
 }

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -21,6 +21,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 
 	// Create handlers
 	authHandler := handlers.NewAuthHandler(userRepo, sessionRepo)
+	oauthHandler := handlers.NewOAuthHandler(userRepo, sessionRepo)
 	categoryHandler := handlers.NewCategoryHandler(categoryRepo, postRepo)
 	postHandler := handlers.NewPostHandler(postRepo)
 	myPostsHandler := handlers.NewMyPostsHandler(postRepo, commentRepo, reactionRepo)
@@ -44,10 +45,10 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	mux.Handle("/forum/api/public/feed", corsMiddleware.Handler(http.HandlerFunc(guestHandler.GetGuestData)))
 	//mux.Handle("/forum/api/allData", corsMiddleware.Handler(http.HandlerFunc(guestHandler.GetGuestData)))
 	mux.Handle("/forum/api/register", corsMiddleware.Handler(http.HandlerFunc(registerLimiter.Limit(authHandler.Register))))
-	// mux.HandleFunc("/auth/google/login", handlers.GoogleLoginHandler)
-	// mux.HandleFunc("/auth/google/callback", handlers.GoogleCallbackHandler)
-	// mux.HandleFunc("/auth/github/login", handlers.GitHubLoginHandler)
-	// mux.HandleFunc("/oauth/github/callback", handlers.GitHubCallbackHandler)
+	mux.HandleFunc("/auth/google/login", oauthHandler.GoogleLoginHandler)
+	mux.HandleFunc("/auth/google/callback", oauthHandler.GoogleCallbackHandler)
+	mux.HandleFunc("/auth/github/login", oauthHandler.GitHubLoginHandler)
+	mux.HandleFunc("/oauth/github/callback", oauthHandler.GitHubCallbackHandler)
 
 	mux.Handle("/forum/api/session/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.Login)))
 	mux.Handle("/forum/api/session/logout", corsMiddleware.Handler(http.HandlerFunc(authHandler.Logout)))


### PR DESCRIPTION
## Summary
- introduce `oauth` package with a generic Provider interface
- move Google and GitHub implementations into the new package
- refactor OAuth handlers to use the generic provider

## Testing
- `gofmt -w API/handlers/oauth_handlers.go API/oauth/providers.go`
- `GOTOOLCHAIN=local go build ./...` *(fails: go.mod requires go >= 1.24.1)*

------
https://chatgpt.com/codex/tasks/task_e_686627e0c7dc8324ae8786a11e0e87fc